### PR TITLE
Update base URL in metadata

### DIFF
--- a/src/app/(pages)/layout.tsx
+++ b/src/app/(pages)/layout.tsx
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
   description:
     "MDM Engineering: London experts in structural design, committed to safety, innovation, and sustainable building. Transforming the city's skyline since 2017.",
   metadataBase: new URL(
-    `https://${process.env.VERCEL_URL || `localhost:${process.env.PORT || "3000"}`}`,
+    "https://mdm-structural-and-civil-engineering.vercel.app/",
   ),
   alternates: {
     canonical: "/",


### PR DESCRIPTION
The base URL used in the metadata of layout.tsx has been updated. Previously, it was dynamically generated based on environment variables. Now, it's a hardcoded string pointing to our Vercel app. This change simplifies the code and ensures consistency across different environments.